### PR TITLE
Improve TournamentEndEvent and Discord webhook

### DIFF
--- a/src/main/java/net/zithium/tournaments/discord/WebhookListener.java
+++ b/src/main/java/net/zithium/tournaments/discord/WebhookListener.java
@@ -55,7 +55,10 @@ public class WebhookListener implements Listener {
     private String replacePlaceholders(@NotNull String text, TournamentData tournament) {
         for (int i = 1; i <= 3; i++) {
             OfflinePlayer player = tournament.getPlayerFromPosition(i);
-            String playerName = (player != null) ? player.getName() : "Unknown";
+
+            if (player == null) return "Unknown"; // Player is not found
+            if (player.getFirstPlayed() == 0) return null; // Player has never joined before
+            String playerName = player.getName();
 
             // Ensure that both text and playerName are not null before replacement
             if (playerName != null) {

--- a/src/main/java/net/zithium/tournaments/tournament/Tournament.java
+++ b/src/main/java/net/zithium/tournaments/tournament/Tournament.java
@@ -150,14 +150,12 @@ public class Tournament {
     public void stop() {
         if (debug()) plugin.getLogger().log(Level.INFO, "Executing tournament stop.");
         if (status != TournamentStatus.ACTIVE) throw new IllegalStateException("Attempted to stop a Tournament that is not ACTIVE");
-
-        Bukkit.getScheduler().runTask(plugin, () ->
-                Bukkit.getPluginManager().callEvent(new TournamentEndEvent(this, new TournamentData(identifier, gameUniqueId, new LinkedHashMap<>(sortedParticipants))))
-        );
         status = TournamentStatus.ENDED;
         
         if (updateTask != null) updateTask.cancel();
         update();
+
+        Bukkit.getPluginManager().callEvent(new TournamentEndEvent(this, new TournamentData(identifier, gameUniqueId, new LinkedHashMap<>(sortedParticipants))));
 
         if (challenge) return;
 


### PR DESCRIPTION
This PR does two things;

- Ensures the participants are updated before the event is called
- Better check to define if an entry is found or not in the Webhook as `Bukkit#getOfflinePlayer(UUID)` does not return a `null` object.