### PR TITLE
Add new feature for blocking rewards on zero-score tournament placements

### DIFF
--- a/src/main/java/net/zithium/tournaments/discord/WebhookListener.java
+++ b/src/main/java/net/zithium/tournaments/discord/WebhookListener.java
@@ -35,18 +35,23 @@ public class WebhookListener implements Listener {
 
         String content = config.getString("discord_webhook.content", "'discord_webhook.content' not found.");
 
-        for (int i = 1; i <= 3; i++) {
-            OfflinePlayer player = tournament.getPlayerFromPosition(i);
-            if (player != null) {
-                String playerName = player.getName();
-                if (playerName != null) {
-                    content = content.replace("{" + i + "_PLACE}", playerName);
-                }
-            } else {
-                content = content.replace("{" + i + "_PLACE}", "Unknown");
-            }
+        boolean blockZeroScoreRewards = config.getBoolean("block_zero_score_rewards", false);
 
-            Integer playerScore = tournament.getScoreFromPosition(i);
+        for (int i = 1; i <= 3; i++) {
+            int playerScore = tournament.getScoreFromPosition(i);
+
+            if (blockZeroScoreRewards && playerScore == 0) {
+                content = content.replace("{" + i + "_PLACE}", "No score");
+            } else {
+                OfflinePlayer player = tournament.getPlayerFromPosition(i);
+                if (player != null) {
+                    String playerName = player.getName();
+                        content = content.replace("{" + i + "_PLACE}", playerName != null ? playerName : "Unknown");
+                    } else {
+                        content = content.replace("{" + i + "_PLACE}", "Unknown");
+                    }
+                }
+
             content = content.replace("{" + i + "_SCORE}", String.valueOf(playerScore));
         }
 

--- a/src/main/java/net/zithium/tournaments/tournament/Tournament.java
+++ b/src/main/java/net/zithium/tournaments/tournament/Tournament.java
@@ -159,9 +159,18 @@ public class Tournament {
 
         if (challenge) return;
 
+        boolean blockZeroScoreRewards = plugin.getConfig().getBoolean("block_zero_score_rewards", false);
+
         for (int position : rewards.keySet()) {
             OfflinePlayer player = getPlayerFromPosition(position);
             if (player == null) continue;
+
+            // Skip reward delivery if block_zero_score_rewards is enabled and the player's score is zero
+            if (blockZeroScoreRewards && getScoreFromPosition(position) == 0) {
+                if (debug()) plugin.getLogger().log(Level.INFO, "Skipping reward for position " + position + " — score is zero.");
+                continue;
+            }
+
             if (player.isOnline()) {
                 Bukkit.getScheduler().runTask(plugin, () -> actionManager.executeActions(player.getPlayer(), rewards.get(position)));
                 if (debug()) plugin.getLogger().log(Level.INFO, "Executed end actions for " + player.getName() + "(" + player.getUniqueId() + ")");

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -56,3 +56,7 @@ playtime_objective_task_update: 200 # 10 seconds
 # Should the plugin report stats to https://bstats.org/
 # All usage statistics are anonymous and has zero impact on performance.
 enable_metrics: true
+
+# Should rewards be blocked for players who finish a tournament placement with a score of zero?
+# If true, players at a rewarded position with 0 score will NOT receive their rewards.
+block_zero_score_rewards: false


### PR DESCRIPTION
## feat: Block rewards for zero-score tournament placements

### Summary

Adds a configurable option to prevent reward delivery for players who finish a tournament at a rewarded placement but with a score of zero. Additionally, the Discord webhook now reflects this behavior by displaying `No score` instead of the player's name for those positions.

### Motivation

In tournaments where not enough players participate, rewarded positions (e.g. 2nd, 3rd place) can be occupied by players with a score of `0`. Under the previous behavior, those players would still receive their rewards and appear normally in the Discord webhook. This change gives server administrators control over that behavior on both fronts.

### Changes

**`src/main/resources/config.yml`**
- Added `block_zero_score_rewards` option (defaults to `false` to preserve existing behavior)

**`src/main/java/.../tournament/Tournament.java`**
- In `stop()`, reads `block_zero_score_rewards` from config before iterating over reward positions
- Skips reward delivery (both for online players and the offline action queue) when the option is enabled and `getScoreFromPosition(position) == 0`
- Logs the skip at DEBUG level when debug mode is active

**`src/main/java/.../discord/WebhookListener.java`**
- Reads `block_zero_score_rewards` from config before building the webhook message
- Replaces `{N_PLACE}` with `No score` when the option is enabled and the position score is zero

### Behavior

| `block_zero_score_rewards` | Player score | Reward | Discord `{N_PLACE}` |
|---|---|---|---|
| `false` (default) | any | Delivered | Player name |
| `true` | `> 0` | Delivered | Player name |
| `true` | `0` | **Skipped** | **`No score`** |

### Notes

- Fully backward-compatible — no behavior change unless the option is explicitly set to `true`
- No impact on challenge-type tournaments (already handled by the early `return` on `challenge`)
- Reload with `/tournament reload` after changing the config value